### PR TITLE
Update LinkCo2 and Link rel attributes

### DIFF
--- a/src/components/WebsiteCarbonBadge.tsx
+++ b/src/components/WebsiteCarbonBadge.tsx
@@ -144,7 +144,7 @@ const WebsiteCarbonBadge = (props: WebsiteCarbonBadgeProps) => {
       <div>
         <LinkCo2
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           href={`https://www.websitecarbon.com/website/${props.url}`}
         >
           {data.co2 ? data.co2 : "-"}g {ps.p1} CO<Sub>2</Sub>/{ps.p2}
@@ -152,7 +152,7 @@ const WebsiteCarbonBadge = (props: WebsiteCarbonBadgeProps) => {
         <Link
           dark={props.dark}
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           href="https://websitecarbon.com"
         >
           Website Carbon


### PR DESCRIPTION
Add `rel="noreferrer"` to prevent user generated link hrefs actions from creating security vulnerabilities on old browsers.

Inspired by recommended config of [eslint-plugin-react rules](https://github.com/jsx-eslint/eslint-plugin-react/blob/c9f5eb264e881f7de66188cbb20904fa8edf3985/docs/rules/jsx-no-target-blank.md)

Hope this help.